### PR TITLE
docs: Fix function write_req_to_token_pool_triton typo

### DIFF
--- a/sglang/code-walk-through/readme-CN.md
+++ b/sglang/code-walk-through/readme-CN.md
@@ -45,7 +45,7 @@
 1. 基于 Attention Backend 的 Radix Cache 管理。
 2. `get_next_batch_to_run`：如何为每批次请求提取和写入 KV 缓存。
 3. `get_model_worker_batch`。
-4. `write_req_to_token_pool_trition`。
+4. `write_req_to_token_pool_triton`。
 5. 使用 CUDA Graphs 优化 Attention Backend。
 6. 重叠调度策略（overlap scheduling）。
 

--- a/sglang/code-walk-through/readme.md
+++ b/sglang/code-walk-through/readme.md
@@ -49,7 +49,7 @@ All the discussions are based on release [v0.4.0](https://github.com/sgl-project
 1. Radix Cache Management with Attention Backend.
 2. `get_next_batch_to_run`: How to fetch and write KV cache for requests in each batch.
 3. `get_model_worker_batch`.
-4. `write_req_to_token_pool_trition`.
+4. `write_req_to_token_pool_triton`.
 5. CUDA Graphs for Attention Backend.
 6. Overlapping scheduling.
 


### PR DESCRIPTION
## Motivation
The function name `write_req_to_token_pool_trition` is incorrectly spelled and doesn't match the source code.

## Modifications
Rename `write_req_to_token_pool_trition` to `write_req_to_token_pool_triton` to correct the typo.