### PR TITLE
Add FlashOffload (SGLang offloading deep-dive) to SGLang notes

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -123,6 +123,7 @@ $$
 - [Pending Review] [Online Update Weights](./sglang/online-update-weights/readme.md)：介绍 SGLang 中 `online_update_weights` 接口的实现，区别于从磁盘读取权重的 `update_weights`，该接口从训练 engine 中直接通过 nccl 广播新的权重。
 - [Pending Review] [SGLang Verl Engine 优化解析](./sglang/sglang-verl-engine/readme.md)：解析 SGLang 中 verl engine 的优化，包括 `update_weights_from_tensor` 等接口的实现。
 - [Latency Accelerate For Weight Updates](./sglang/latency-accelerate-for-weight-updates/readme-CN.md)
+- [FlashOffload: 7x Cheaper Prefills with Offloading](https://blog.doubleword.ai/flashoffload)：扩展了 SGLang 的 offloading 引擎，通过双缓冲（double-buffered）CPU offloading 将权重传输延迟隐藏在 GPU 计算之后，为 Grace Hopper 上 compute-bound 的 workload 带来更廉价的 prefill。
 
 ### 使用与实践
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Coming back to the topic, this series of podcasts started in August 2024, when I
 - [Pending Review] [Online Update Weights](./sglang/online-update-weights/readme.md): Introduction to the implementation of the `online_update_weights` interface in SGLang. Unlike `update_weights` which reads weights from the disk, this interface broadcasts new weights directly from the training engine via NCCL.
 - [Pending Review] [SGLang Verl Engine Optimization Analysis](./sglang/sglang-verl-engine/readme.md): Analysis of optimizations in the SGLang verl engine, including the implementation of interfaces like `update_weights_from_tensor`.
 - [Latency Accelerate For Weight Updates](./sglang/latency-accelerate-for-weight-updates/readme-CN.md)
+- [FlashOffload: 7x Cheaper Prefills with Offloading](https://blog.doubleword.ai/flashoffload): Extends SGLang's offloading engine with double-buffered CPU offloading that hides weight-transfer latency behind GPU compute, delivering cheaper prefills for compute-bound workloads on Grace Hopper.
 
 ### Usage and Practice
 


### PR DESCRIPTION
Adds one external technical deep-dive to **SGLang Learning Notes → Core Architecture and Optimization**:

- [FlashOffload: 7x Cheaper Prefills with Offloading](https://blog.doubleword.ai/flashoffload)

The post extends SGLang's offloading engine with double-buffered CPU offloading that hides weight-transfer latency behind GPU compute, cutting prefill cost for compute-bound workloads on Grace Hopper. It's a system-internals write-up in the same vein as the surrounding SGLang scheduler/KV-cache/weight-update notes, so it sits naturally in that subsection.

Formatting matches neighboring entries (single-dash bullet, `[Title](url): description.`). One entry only; no other changes.