### PR TITLE
Fix name in ASR blog acknowledgments

### DIFF
--- a/sglang/sglang-omni/moss-td-asr.md
+++ b/sglang/sglang-omni/moss-td-asr.md
@@ -231,7 +231,7 @@ Thanks for the joint effort of the OpenMOSS team and SGLang-Omni team.
 
 **MOSS Team:** Donghua Yu, Zhengyuan Lin, Hanfu Chen, Yiyang Zhang, Yang Gao, Zhaoye Fei, Qinyuan Cheng, Shimin Li, Xipeng Qiu.
 
-**SGLang-Omni Team:** Yijiang Tian, Xinli Jing, Xiangrui Ke, Zhihao Guo, Ruoqi Zhang, Lifan Shen, Jintao Qu, Xuxiang Tian, Kaige Li, Ratish P, Haoguang Cai, Zijie Xia, Chenchen Hong, Xuesong Ye, Jingwen Gu, Jiaxin Deng, Jiaxuan Luo, Xinyu Lu, Hao Jin, Chenyang Zhao, Yichi Zhang.
+**SGLang-Omni Team:** Yijiang Tian, Xinli Jing, Xiangrui Ke, Zhihao Guo, Ruoyi Zhang, Lifan Shen, Jintao Qu, Xuxiang Tian, Kaige Li, Ratish P, Haoguang Cai, Zijie Xia, Chenchen Hong, Xuesong Ye, Jingwen Gu, Jiaxin Deng, Jiaxuan Luo, Xinyu Lu, Hao Jin, Chenyang Zhao, Yichi Zhang.
 
 ## Learn More
 


### PR DESCRIPTION
Fix a name in the MOSS-TD ASR blog acknowledgments: Ruoqi Zhang -> Ruoyi Zhang.